### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const base = process.env.BASE_PATH || '/'
+const base = process.env.BASE_PATH || './'
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- set the default Vite base path to a relative value so assets resolve correctly when hosted on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfd986a424833097c4466cce4c6739