### PR TITLE
Switch filters to toggles and extend distribution chart options

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -182,25 +182,60 @@ main {
   min-width: 160px;
 }
 
-.control-group label,
+.toggle-group {
+  gap: 0.6rem;
+}
+
+.control-group .control-label,
 .metric-toggle span {
   font-weight: 600;
   font-size: 0.9rem;
 }
 
-select {
-  padding: 0.6rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
-  background: #fff;
-  font-size: 0.95rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
+.toggle-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-select:focus {
+.toggle-button {
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--muted);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  white-space: nowrap;
+}
+
+.toggle-button.small {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.85rem;
+}
+
+.toggle-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.toggle-button:focus-visible {
   outline: none;
   border-color: var(--accent);
+  color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.toggle-button.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  box-shadow: 0 10px 20px rgba(63, 106, 224, 0.2);
+}
+
+.toggle-button.active:focus-visible {
+  box-shadow: 0 0 0 3px var(--accent-soft), 0 10px 20px rgba(63, 106, 224, 0.2);
 }
 
 .metric-toggle {
@@ -278,11 +313,29 @@ select:focus {
   box-shadow: 0 16px 32px rgba(31, 41, 51, 0.08);
 }
 
+.chart-area {
+  position: relative;
+  height: 220px;
+}
+
+.chart-area canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
 .chart-header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: flex-start;
   margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.chart-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .chart-header h2 {
@@ -294,6 +347,13 @@ select:focus {
   margin: 0;
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+.chart-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 .table-section {
@@ -368,6 +428,6 @@ footer {
   .chart-header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.25rem;
+    gap: 0.5rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
       <div>
         <h1>Church Attendance Dashboard</h1>
         <p class="subtitle">
-          Explore weekly attendance and kids check-in trends for Central and North
-          sites from 2022 to 2024.
+          Explore weekly attendance and kids check-in trends tailored to the
+          filters and dataset you choose.
         </p>
       </div>
     </header>
@@ -29,7 +29,7 @@
         <article class="data-card">
           <h2 id="dataManagementHeading">Data source</h2>
           <p id="datasetStatus" class="dataset-status" role="status">
-            Using placeholder dataset generated for Central and North sites (2022–2024).
+            Using placeholder dataset generated for demonstration across multiple sites and years.
           </p>
           <div class="data-actions">
             <label class="file-upload">
@@ -56,17 +56,17 @@
       </section>
     
       <section class="controls">
-        <div class="control-group">
-          <label for="yearSelect">Year</label>
-          <select id="yearSelect"></select>
+        <div class="control-group toggle-group">
+          <span class="control-label" id="yearToggleLabel">Year</span>
+          <div class="toggle-options" id="yearToggle" role="radiogroup" aria-labelledby="yearToggleLabel"></div>
         </div>
-        <div class="control-group">
-          <label for="siteSelect">Site</label>
-          <select id="siteSelect"></select>
+        <div class="control-group toggle-group">
+          <span class="control-label" id="siteToggleLabel">Site</span>
+          <div class="toggle-options" id="siteToggle" role="radiogroup" aria-labelledby="siteToggleLabel"></div>
         </div>
-        <div class="control-group">
-          <label for="serviceSelect">Service</label>
-          <select id="serviceSelect"></select>
+        <div class="control-group toggle-group">
+          <span class="control-label" id="serviceToggleLabel">Service</span>
+          <div class="toggle-options" id="serviceToggle" role="radiogroup" aria-labelledby="serviceToggleLabel"></div>
         </div>
         <div class="control-group metric-toggle">
           <span>Metric</span>
@@ -114,21 +114,66 @@
             <h2>Weekly Trend</h2>
             <p>Aggregated by Sunday</p>
           </div>
-          <canvas id="trendChart" height="300"></canvas>
+          <div class="chart-area">
+            <canvas id="trendChart"></canvas>
+          </div>
         </article>
         <article class="chart-card">
           <div class="chart-header">
             <h2>Monthly Overview</h2>
             <p>Totals grouped by month</p>
           </div>
-          <canvas id="monthlyChart" height="300"></canvas>
+          <div class="chart-area">
+            <canvas id="monthlyChart"></canvas>
+          </div>
         </article>
         <article class="chart-card">
           <div class="chart-header">
-            <h2>Distribution</h2>
-            <p id="distributionLabel">Share by service</p>
+            <div class="chart-title">
+              <h2>Distribution</h2>
+              <p id="distributionLabel">Share by service</p>
+            </div>
+            <div
+              class="chart-toggle-group"
+              id="distributionToggle"
+              role="radiogroup"
+              aria-label="Show distribution by"
+            >
+              <button
+                type="button"
+                class="toggle-button small active"
+                data-value="Service"
+                role="radio"
+                aria-checked="true"
+                tabindex="0"
+              >
+                Service
+              </button>
+              <button
+                type="button"
+                class="toggle-button small"
+                data-value="Site"
+                role="radio"
+                aria-checked="false"
+                tabindex="-1"
+              >
+                Site
+              </button>
+              <button
+                type="button"
+                class="toggle-button small"
+                data-value="Year"
+                role="radio"
+                aria-checked="false"
+                tabindex="-1"
+              >
+                Year
+              </button>
+            </div>
           </div>
-          <canvas id="distributionChart" height="300"></canvas>
+          <div class="chart-area">
+            <canvas id="distributionChart"></canvas>
+          </div>
         </article>
       </section>
 


### PR DESCRIPTION
## Summary
- replace the year/site/service dropdowns with toggle groups and update the filter logic to drive them
- add styling for the toggle controls and distribution header toggle buttons
- let the distribution pie chart and summary switch between service, site, and year groupings via new buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfe953525c833086f8487ba4659319