### PR TITLE
Allow multi-select data filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,15 +58,15 @@
       <section class="controls">
         <div class="control-group toggle-group">
           <span class="control-label" id="yearToggleLabel">Year</span>
-          <div class="toggle-options" id="yearToggle" role="radiogroup" aria-labelledby="yearToggleLabel"></div>
+          <div class="toggle-options" id="yearToggle" role="group" aria-labelledby="yearToggleLabel"></div>
         </div>
         <div class="control-group toggle-group">
           <span class="control-label" id="siteToggleLabel">Site</span>
-          <div class="toggle-options" id="siteToggle" role="radiogroup" aria-labelledby="siteToggleLabel"></div>
+          <div class="toggle-options" id="siteToggle" role="group" aria-labelledby="siteToggleLabel"></div>
         </div>
         <div class="control-group toggle-group">
           <span class="control-label" id="serviceToggleLabel">Service</span>
-          <div class="toggle-options" id="serviceToggle" role="radiogroup" aria-labelledby="serviceToggleLabel"></div>
+          <div class="toggle-options" id="serviceToggle" role="group" aria-labelledby="serviceToggleLabel"></div>
         </div>
         <div class="control-group metric-toggle">
           <span>Metric</span>


### PR DESCRIPTION
## Summary
- enable multi-select year, site, and service filters with shared helper utilities and updated toggle rendering
- refresh dependent service options and active filter descriptions to account for multiple selections
- adjust control markup roles so the toggle groups reflect their multi-select behavior

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cff4fd6bcc8330a29740447bfdc9c7