### PR TITLE
Fix timezone-safe date parsing and improve chart accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,13 @@
             <p>Aggregated by Sunday</p>
           </div>
           <div class="chart-area">
-            <canvas id="trendChart"></canvas>
+            <canvas
+              id="trendChart"
+              role="img"
+              aria-label="Weekly attendance trend line chart."
+            >
+              Weekly trend line chart showing attendance totals.
+            </canvas>
           </div>
         </article>
         <article class="chart-card">
@@ -137,7 +143,13 @@
             <p>Totals grouped by month</p>
           </div>
           <div class="chart-area">
-            <canvas id="monthlyChart"></canvas>
+            <canvas
+              id="monthlyChart"
+              role="img"
+              aria-label="Monthly attendance totals bar chart."
+            >
+              Monthly bar chart showing attendance totals.
+            </canvas>
           </div>
         </article>
         <article class="chart-card">
@@ -185,7 +197,13 @@
             </div>
           </div>
           <div class="chart-area">
-            <canvas id="distributionChart"></canvas>
+            <canvas
+              id="distributionChart"
+              role="img"
+              aria-label="Attendance distribution pie chart by service."
+            >
+              Pie chart showing attendance distribution by service.
+            </canvas>
           </div>
         </article>
       </section>


### PR DESCRIPTION
## Summary
- add a timezone-safe ISO date parser and use it everywhere date math or formatting occurs
- reuse the parser during CSV normalization and table/chart sorting to keep results consistent
- provide accessible names and fallback text for all chart canvases and update them as filters change

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d05b77137c8330b3532cadc56413ed