### PR TITLE
Harden CSV import validation and add security tests

### DIFF
--- a/assets/csvParser.mjs
+++ b/assets/csvParser.mjs
@@ -1,0 +1,200 @@
+import { ensureNoBinaryData, sanitizeTextValue, enforceRowLimit } from './csvSecurity.mjs';
+
+export const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+];
+
+export const monthRank = monthNames.reduce((acc, name, index) => {
+  acc[name] = index;
+  return acc;
+}, {});
+
+export const REQUIRED_HEADERS = [
+  'Week',
+  'Date',
+  'Year',
+  'Month',
+  'Site',
+  'Service',
+  'Attendance',
+  'Kids Checked-in'
+];
+
+function parseCsvLine(line) {
+  const values = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      values.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  values.push(current);
+  return values;
+}
+
+function normalizeMonth(value, date) {
+  if (value) {
+    const match = monthNames.find((month) => month.toLowerCase() === value.toLowerCase());
+    if (match) {
+      return match;
+    }
+  }
+  return monthNames[date.getMonth()];
+}
+
+function normalizeCsvRow(entry) {
+  const weekValue = Number(entry.Week);
+  if (!Number.isFinite(weekValue)) {
+    throw new Error('Week must be a number.');
+  }
+  const week = Math.round(weekValue);
+
+  if (!entry.Date) {
+    throw new Error('Date is required.');
+  }
+
+  const parsedDate = parseIsoDateLocal(entry.Date);
+
+  const site = sanitizeTextValue(entry.Site, 'Site');
+  if (!site) {
+    throw new Error('Site is required.');
+  }
+
+  const service = sanitizeTextValue(entry.Service, 'Service');
+  if (!service) {
+    throw new Error('Service is required.');
+  }
+
+  const attendanceValue = Number(entry.Attendance);
+  if (!Number.isFinite(attendanceValue)) {
+    throw new Error('Attendance must be a number.');
+  }
+  const attendance = Math.round(attendanceValue);
+
+  const kidsValue = Number(entry['Kids Checked-in']);
+  if (!Number.isFinite(kidsValue)) {
+    throw new Error('Kids Checked-in must be a number.');
+  }
+  const kids = Math.round(kidsValue);
+
+  const yearInput = sanitizeTextValue(entry.Year, 'Year');
+  const yearValue = yearInput || String(parsedDate.getFullYear());
+  const monthInput = sanitizeTextValue(entry.Month, 'Month');
+  const monthValue = normalizeMonth(monthInput, parsedDate);
+
+  return {
+    Week: week,
+    Date: entry.Date,
+    Year: yearValue,
+    Month: monthValue,
+    Site: site,
+    Service: service,
+    Attendance: attendance,
+    'Kids Checked-in': kids
+  };
+}
+
+export function parseIsoDateLocal(value) {
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid Date value "${value}".`);
+  }
+
+  const parts = value.split('-');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid Date value "${value}".`);
+  }
+
+  const [yearPart, monthPart, dayPart] = parts;
+  const year = Number(yearPart);
+  const month = Number(monthPart);
+  const day = Number(dayPart);
+
+  if (![year, month, day].every((part) => Number.isInteger(part))) {
+    throw new Error(`Invalid Date value "${value}".`);
+  }
+
+  const date = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    throw new Error(`Invalid Date value "${value}".`);
+  }
+
+  return date;
+}
+
+export function parseCsv(text) {
+  ensureNoBinaryData(text);
+
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (!lines.length) {
+    throw new Error('The CSV file is empty.');
+  }
+
+  const headers = parseCsvLine(lines[0]).map((header) => header.trim());
+  const missing = REQUIRED_HEADERS.filter((header) => !headers.includes(header));
+
+  if (missing.length) {
+    throw new Error(`The CSV file is missing required columns: ${missing.join(', ')}.`);
+  }
+
+  const records = [];
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const rawLine = lines[index];
+    if (!rawLine.trim()) {
+      continue;
+    }
+
+    const values = parseCsvLine(rawLine);
+    const entry = {};
+    headers.forEach((header, headerIndex) => {
+      entry[header] = values[headerIndex]?.trim() ?? '';
+    });
+
+    try {
+      records.push(normalizeCsvRow(entry));
+      enforceRowLimit(records.length);
+    } catch (error) {
+      throw new Error(`Row ${index + 1}: ${error.message}`);
+    }
+  }
+
+  if (!records.length) {
+    throw new Error('The CSV file does not contain any data rows.');
+  }
+
+  return records;
+}

--- a/assets/csvSecurity.mjs
+++ b/assets/csvSecurity.mjs
@@ -1,0 +1,70 @@
+const CONTROL_CHAR_REGEX = /[\u0000-\u0008\u000B-\u000C\u000E-\u001F\u007F]/;
+const DANGEROUS_FORMULA_PREFIX = /^[=+\-@]/;
+const MAX_TEXT_LENGTH = 120;
+
+export const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB
+export const MAX_CSV_ROWS = 10000;
+
+export function describeFileSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 bytes';
+  }
+
+  const units = ['bytes', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  const formatted = unitIndex === 0 ? Math.round(size).toString() : size.toFixed(1).replace(/\.0$/, '');
+  return `${formatted} ${units[unitIndex]}`;
+}
+
+export function ensureNoBinaryData(text) {
+  if (typeof text !== 'string') {
+    throw new Error('Unable to read the file as text.');
+  }
+
+  if (CONTROL_CHAR_REGEX.test(text)) {
+    throw new Error('The CSV file contains unsupported control characters.');
+  }
+}
+
+export function sanitizeTextValue(value, fieldName) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  let stringValue = typeof value === 'string' ? value : String(value);
+
+  if (CONTROL_CHAR_REGEX.test(stringValue)) {
+    throw new Error(`${fieldName} contains unsupported control characters.`);
+  }
+
+  stringValue = stringValue.trim();
+
+  if (!stringValue) {
+    return '';
+  }
+
+  if (DANGEROUS_FORMULA_PREFIX.test(stringValue)) {
+    throw new Error(
+      `${fieldName} cannot start with "${stringValue[0]}" because it may be interpreted as a formula.`
+    );
+  }
+
+  if (stringValue.length > MAX_TEXT_LENGTH) {
+    throw new Error(`${fieldName} must be ${MAX_TEXT_LENGTH} characters or fewer.`);
+  }
+
+  return stringValue;
+}
+
+export function enforceRowLimit(rowCount) {
+  if (rowCount > MAX_CSV_ROWS) {
+    throw new Error(`The CSV file exceeds the maximum allowed ${MAX_CSV_ROWS.toLocaleString()} data rows.`);
+  }
+}

--- a/scripts/testCsvSecurity.mjs
+++ b/scripts/testCsvSecurity.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import {
+  ensureNoBinaryData,
+  sanitizeTextValue,
+  MAX_CSV_ROWS
+} from '../assets/csvSecurity.mjs';
+import { parseCsv } from '../assets/csvParser.mjs';
+
+const CONTROL_BEL = String.fromCharCode(0x07);
+const CONTROL_NUL = String.fromCharCode(0x00);
+
+function expectThrows(fn, messageSubstring) {
+  let errorCaught = false;
+  try {
+    fn();
+  } catch (error) {
+    errorCaught = true;
+    if (messageSubstring) {
+      assert.match(
+        error.message,
+        new RegExp(messageSubstring.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
+    }
+  }
+  assert.ok(errorCaught, 'Expected function to throw an error');
+}
+
+function testSanitizeTextValue() {
+  assert.equal(sanitizeTextValue('  Central  ', 'Site'), 'Central');
+  assert.equal(sanitizeTextValue(2024, 'Year'), '2024');
+  assert.equal(sanitizeTextValue('', 'Optional'), '');
+  expectThrows(() => sanitizeTextValue('=HYPERLINK("http://example.com")', 'Site'), 'Site cannot start');
+  expectThrows(
+    () => sanitizeTextValue(`${CONTROL_BEL}Bell`, 'Site'),
+    'unsupported control characters'
+  );
+}
+
+function testEnsureNoBinaryData() {
+  ensureNoBinaryData('Week,Date\n1,2024-01-07');
+  expectThrows(
+    () => ensureNoBinaryData(`Week,Date\n1,2024-01-07${CONTROL_NUL}`),
+    'unsupported control characters'
+  );
+}
+
+function testParseCsvRejectsFormulaInjection() {
+  const maliciousCsv = [
+    'Week,Date,Year,Month,Site,Service,Attendance,Kids Checked-in',
+    "1,2024-01-07,2024,January,=cmd|' /C calc'!A0,9am,100,10"
+  ].join('\n');
+  expectThrows(() => parseCsv(maliciousCsv), 'Site cannot start');
+}
+
+function testParseCsvRejectsHugeFiles() {
+  const header = 'Week,Date,Year,Month,Site,Service,Attendance,Kids Checked-in';
+  const row = '1,2024-01-07,2024,January,Central,9am,100,10';
+  const rows = new Array(MAX_CSV_ROWS + 1).fill(row);
+  const csv = [header, ...rows].join('\n');
+  expectThrows(() => parseCsv(csv), 'maximum allowed');
+}
+
+function testParseCsvValidData() {
+  const csv = [
+    'Week,Date,Year,Month,Site,Service,Attendance,Kids Checked-in',
+    '1,2024-01-07,2024,January,Central,9am,100,10'
+  ].join('\n');
+  const result = parseCsv(csv);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].Site, 'Central');
+  assert.equal(result[0]['Kids Checked-in'], 10);
+}
+
+function run() {
+  testSanitizeTextValue();
+  testEnsureNoBinaryData();
+  testParseCsvRejectsFormulaInjection();
+  testParseCsvRejectsHugeFiles();
+  testParseCsvValidData();
+  console.log('Security CSV tests passed.');
+}
+
+run();


### PR DESCRIPTION
## Summary
- refactor CSV parsing into a dedicated module that normalizes rows with strict validation and protections against spreadsheet formula injection
- add shared security helpers that reject control characters, enforce per-field length caps, and cap CSV size by file size and row count
- update the upload flow to surface file size errors and add automated security regression tests covering the new guards
- update CSV security tests to synthesize control characters from code points so the source stays textual

## Testing
- `node scripts/testCsvSecurity.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68d0618a69348330832a7f83d1ba5da7