### PR TITLE
Enhance dashboard UX, ingestion, and analytics

### DIFF
--- a/assets/csvParser.mjs
+++ b/assets/csvParser.mjs
@@ -67,7 +67,18 @@ function normalizeMonth(value, date) {
   return monthNames[date.getMonth()];
 }
 
-function normalizeCsvRow(entry) {
+export function computeIsoWeek(date) {
+  const temp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNumber = (temp.getUTCDay() + 6) % 7;
+  temp.setUTCDate(temp.getUTCDate() - dayNumber + 3);
+  const firstThursday = new Date(Date.UTC(temp.getUTCFullYear(), 0, 4));
+  const week =
+    1 + Math.round((temp.getTime() - firstThursday.getTime()) / (7 * 24 * 60 * 60 * 1000));
+  const isoYear = temp.getUTCFullYear();
+  return { isoWeek: week, isoYear };
+}
+
+export function normalizeCsvRow(entry) {
   const weekValue = Number(entry.Week);
   if (!Number.isFinite(weekValue)) {
     throw new Error('Week must be a number.');
@@ -107,6 +118,9 @@ function normalizeCsvRow(entry) {
   const monthInput = sanitizeTextValue(entry.Month, 'Month');
   const monthValue = normalizeMonth(monthInput, parsedDate);
 
+  const { isoWeek, isoYear } = computeIsoWeek(parsedDate);
+  const isoWeekIndex = String(isoWeek).padStart(2, '0');
+
   return {
     Week: week,
     Date: entry.Date,
@@ -115,7 +129,10 @@ function normalizeCsvRow(entry) {
     Site: site,
     Service: service,
     Attendance: attendance,
-    'Kids Checked-in': kids
+    'Kids Checked-in': kids,
+    IsoWeek: isoWeek,
+    IsoYear: String(isoYear),
+    YearWeek: `${isoYear}-${isoWeekIndex}`
   };
 }
 

--- a/assets/csvWorker.js
+++ b/assets/csvWorker.js
@@ -1,0 +1,61 @@
+import Papa from 'https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.mjs';
+import { REQUIRED_HEADERS, normalizeCsvRow } from './csvParser.mjs';
+import { ensureNoBinaryData, enforceRowLimit } from './csvSecurity.mjs';
+
+self.addEventListener('message', (event) => {
+  const { text } = event.data || {};
+
+  if (typeof text !== 'string') {
+    self.postMessage({ type: 'error', message: 'Unable to read the file as text.' });
+    return;
+  }
+
+  try {
+    ensureNoBinaryData(text);
+
+    const results = Papa.parse(text, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (header) => (typeof header === 'string' ? header.trim() : header)
+    });
+
+    const headers = Array.isArray(results.meta?.fields)
+      ? results.meta.fields.map((field) => field.trim())
+      : [];
+
+    const missing = REQUIRED_HEADERS.filter((header) => !headers.includes(header));
+    if (missing.length) {
+      throw new Error(`Missing column${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`);
+    }
+
+    const records = [];
+
+    results.data.forEach((row, index) => {
+      const entry = {};
+      headers.forEach((header) => {
+        const value = row[header];
+        entry[header] = typeof value === 'string' ? value.trim() : value ?? '';
+      });
+
+      const isEmptyRow = headers.every((header) => String(entry[header] ?? '').trim() === '');
+      if (isEmptyRow) {
+        return;
+      }
+
+      try {
+        records.push(normalizeCsvRow(entry));
+        enforceRowLimit(records.length);
+      } catch (error) {
+        throw new Error(`Row ${index + 2}: ${error.message}`);
+      }
+    });
+
+    if (!records.length) {
+      throw new Error('The CSV file does not contain any data rows.');
+    }
+
+    self.postMessage({ type: 'success', payload: records });
+  } catch (error) {
+    self.postMessage({ type: 'error', message: error.message || 'Failed to parse CSV file.' });
+  }
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -6,6 +6,9 @@
   --muted: #5b6878;
   --accent: #3f6ae0;
   --accent-soft: rgba(63, 106, 224, 0.1);
+  --accent-alt: #2eb88a;
+  --danger: #ef5b5b;
+  --warning: #f2a93b;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -73,6 +76,63 @@ body {
   flex-direction: column;
   gap: 1rem;
   width: 100%;
+}
+
+.ingest-notices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ingest-notice {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(63, 106, 224, 0.15);
+  background: rgba(63, 106, 224, 0.08);
+  color: var(--accent);
+  font-weight: 500;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.ingest-notice.warning {
+  background: rgba(242, 169, 59, 0.1);
+  border-color: rgba(242, 169, 59, 0.3);
+  color: var(--warning);
+}
+
+.ingest-notice.error {
+  background: rgba(239, 91, 91, 0.12);
+  border-color: rgba(239, 91, 91, 0.3);
+  color: var(--danger);
+}
+
+.ingest-notice pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-size: 0.85rem;
+}
+
+.help-panel {
+  border-radius: 0.85rem;
+  background: rgba(63, 106, 224, 0.05);
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(63, 106, 224, 0.15);
+}
+
+.help-panel summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.help-panel__content {
+  margin-top: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .data-card h2 {
@@ -163,6 +223,20 @@ body {
   box-shadow: none;
 }
 
+.pill-button.tertiary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px dashed rgba(63, 106, 224, 0.4);
+  box-shadow: none;
+  padding: 0.4rem 0.9rem;
+}
+
+.pill-button.tertiary:hover,
+.pill-button.tertiary:focus-visible {
+  box-shadow: none;
+  border-color: var(--accent);
+}
+
 .guidelines summary {
   font-weight: 600;
   cursor: pointer;
@@ -177,6 +251,50 @@ body {
 
 .guidelines li {
   margin-bottom: 0.5rem;
+}
+
+.empty-state {
+  background: var(--surface);
+  border-radius: 1rem;
+  box-shadow: 0 16px 32px rgba(31, 41, 51, 0.08);
+  padding: 2rem;
+  text-align: center;
+}
+
+.empty-state__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.empty-state h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.empty-state p {
+  margin: 0;
+  max-width: 40rem;
+  color: var(--muted);
+}
+
+.example-row {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid rgba(63, 106, 224, 0.2);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.example-row th,
+.example-row td {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.example-row thead {
+  background: rgba(63, 106, 224, 0.12);
 }
 
 .controls {
@@ -194,6 +312,49 @@ body {
   flex-direction: column;
   gap: 0.4rem;
   min-width: 160px;
+}
+
+.control-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.control-actions {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.control-action {
+  border: none;
+  background: none;
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.5rem;
+}
+
+.control-action:hover,
+.control-action:focus-visible {
+  background: rgba(63, 106, 224, 0.12);
+  outline: none;
+}
+
+.search-group input[type='search'] {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-group input[type='search']:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .toggle-group {
@@ -270,8 +431,24 @@ body {
   font-weight: 600;
 }
 
-.metric-toggle input[type='radio'] {
+.metric-toggle input[type='radio'],
+.metric-toggle input[type='checkbox'] {
   accent-color: var(--accent);
+}
+
+.toggle-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  background: rgba(63, 106, 224, 0.08);
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  color: var(--accent);
+}
+
+.toggle-inline input[type='checkbox'] {
+  accent-color: var(--accent-alt);
 }
 
 .filters-summary {
@@ -284,6 +461,13 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  background: linear-gradient(180deg, rgba(245, 247, 251, 0.96), rgba(245, 247, 251, 0.4));
+  padding: 0.75rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 12px 28px rgba(31, 41, 51, 0.12);
 }
 
 .summary-card {
@@ -371,6 +555,42 @@ body {
   --summary-accent-soft: rgba(168, 85, 247, 0.24);
 }
 
+.insight-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.story-card {
+  background: var(--surface);
+  border-radius: 1rem;
+  box-shadow: 0 16px 32px rgba(31, 41, 51, 0.08);
+  padding: 1.5rem;
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.story-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.story-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.story-highlights {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--accent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
 .charts {
   display: flex;
   flex-direction: column;
@@ -382,6 +602,14 @@ body {
   padding: 1.5rem;
   border-radius: 1rem;
   box-shadow: 0 16px 32px rgba(31, 41, 51, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chart-card.disabled {
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .chart-area {
@@ -401,6 +629,13 @@ body {
   margin-bottom: 0.75rem;
   flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+.chart-actions {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .chart-title {
@@ -439,6 +674,7 @@ body {
   justify-content: space-between;
   align-items: baseline;
   margin-bottom: 1rem;
+  gap: 1rem;
 }
 
 .table-header h2 {
@@ -448,6 +684,27 @@ body {
 .table-header p {
   margin: 0;
   color: var(--muted);
+}
+
+.table-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.table-controls select {
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.65rem;
+  font-size: 0.9rem;
+}
+
+.table-controls select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .table-wrapper {
@@ -473,6 +730,29 @@ thead th {
   padding: 0.9rem 1rem;
   font-weight: 600;
   color: rgba(31, 41, 51, 0.78);
+  position: sticky;
+  top: 0;
+  background: linear-gradient(135deg, rgba(63, 106, 224, 0.22), rgba(63, 106, 224, 0.1));
+  cursor: pointer;
+}
+
+thead th.sort-asc::after,
+thead th.sort-desc::after {
+  content: '';
+  display: inline-block;
+  margin-left: 0.35rem;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+}
+
+thead th.sort-asc::after {
+  border-bottom: 6px solid var(--accent);
+}
+
+thead th.sort-desc::after {
+  border-top: 6px solid var(--accent);
 }
 
 tbody td {
@@ -516,5 +796,12 @@ tbody tr:hover {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
+  }
+
+  .summaries {
+    position: static;
+    box-shadow: none;
+    padding: 0;
+    background: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   </head>
   <body>
     <header class="page-header">
@@ -29,9 +28,10 @@
       <section class="data-management" aria-labelledby="dataManagementHeading">
         <article class="data-card">
           <h2 id="dataManagementHeading">Data source</h2>
-          <p id="datasetStatus" class="dataset-status" role="status">
+          <p id="datasetStatus" class="dataset-status" role="status" aria-live="polite">
             Using placeholder dataset generated for demonstration across multiple sites and years.
           </p>
+          <div id="ingestNotices" class="ingest-notices" aria-live="polite"></div>
           <div class="data-actions">
             <label class="file-upload">
               <span>Upload CSV dataset</span>
@@ -40,6 +40,20 @@
             <button type="button" id="resetDataset" class="pill-button secondary">Reset to placeholder</button>
             <a class="pill-button" href="data/attendance.csv" download>Download sample CSV</a>
           </div>
+          <details class="help-panel" open>
+            <summary>Need a hand preparing your CSV?</summary>
+            <div class="help-panel__content">
+              <p><strong>Required columns:</strong> Week, Date (YYYY-MM-DD), Year, Month, Site, Service, Attendance, Kids Checked-in.</p>
+              <p>
+                Remove blank rows, keep values numeric, and ensure one row per Site &times; Service &times; Date combination.
+                We'll trim extra spaces, normalize month names, and flag duplicates for you.
+              </p>
+              <p>
+                Having trouble? Common fixes include renaming headers to match exactly, converting Excel dates to text, and
+                saving the file as UTF-8 CSV.
+              </p>
+            </div>
+          </details>
           <details class="guidelines">
             <summary>CSV formatting guidelines</summary>
             <ul>
@@ -55,22 +69,77 @@
           </details>
         </article>
       </section>
-    
+
+      <section id="emptyState" class="empty-state" aria-live="polite" hidden>
+        <div class="empty-state__content">
+          <h2>Load a CSV to begin</h2>
+          <p>Upload your attendance CSV to unlock KPIs, charts, and insights tailored to your filters.</p>
+          <table class="example-row" aria-label="Example CSV row">
+            <thead>
+              <tr>
+                <th>Week</th>
+                <th>Date</th>
+                <th>Year</th>
+                <th>Month</th>
+                <th>Site</th>
+                <th>Service</th>
+                <th>Attendance</th>
+                <th>Kids Checked-in</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>12</td>
+                <td>2024-03-24</td>
+                <td>2024</td>
+                <td>March</td>
+                <td>Downtown</td>
+                <td>9am Gathering</td>
+                <td>142</td>
+                <td>36</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
       <section class="controls">
         <div class="control-group toggle-group">
-          <span class="control-label" id="yearToggleLabel">Year</span>
+          <div class="control-header">
+            <span class="control-label" id="yearToggleLabel">Year</span>
+            <div class="control-actions" aria-hidden="true">
+              <button type="button" class="control-action" data-target="year" data-action="select">Select all</button>
+              <button type="button" class="control-action" data-target="year" data-action="clear">Clear all</button>
+            </div>
+          </div>
           <div class="toggle-options" id="yearToggle" role="group" aria-labelledby="yearToggleLabel"></div>
         </div>
         <div class="control-group toggle-group">
-          <span class="control-label" id="siteToggleLabel">Site</span>
+          <div class="control-header">
+            <span class="control-label" id="siteToggleLabel">Site</span>
+            <div class="control-actions" aria-hidden="true">
+              <button type="button" class="control-action" data-target="site" data-action="select">Select all</button>
+              <button type="button" class="control-action" data-target="site" data-action="clear">Clear all</button>
+            </div>
+          </div>
           <div class="toggle-options" id="siteToggle" role="group" aria-labelledby="siteToggleLabel"></div>
         </div>
         <div class="control-group toggle-group">
-          <span class="control-label" id="serviceToggleLabel">Service</span>
+          <div class="control-header">
+            <span class="control-label" id="serviceToggleLabel">Service</span>
+            <div class="control-actions" aria-hidden="true">
+              <button type="button" class="control-action" data-target="service" data-action="select">Select all</button>
+              <button type="button" class="control-action" data-target="service" data-action="clear">Clear all</button>
+            </div>
+          </div>
           <div class="toggle-options" id="serviceToggle" role="group" aria-labelledby="serviceToggleLabel"></div>
         </div>
+        <div class="control-group search-group">
+          <label for="quickSearch">Quick search</label>
+          <input type="search" id="quickSearch" placeholder="Find a site or service" />
+        </div>
         <div class="control-group metric-toggle">
-          <span>Metric</span>
+          <span>Primary metric</span>
           <label>
             <input type="radio" name="metric" value="Attendance" checked />
             Attendance
@@ -78,6 +147,23 @@
           <label>
             <input type="radio" name="metric" value="Kids Checked-in" />
             Kids Checked-in
+          </label>
+        </div>
+        <div class="control-group metric-toggle">
+          <span>Weekly trend metrics</span>
+          <label>
+            <input type="checkbox" class="trend-metric" value="Attendance" checked />
+            Attendance
+          </label>
+          <label>
+            <input type="checkbox" class="trend-metric" value="Kids Checked-in" />
+            Kids Checked-in
+          </label>
+        </div>
+        <div class="control-group toggle-group include-zero-group">
+          <label class="toggle-inline">
+            <input type="checkbox" id="includeZeros" />
+            Include zero attendance entries
           </label>
         </div>
       </section>
@@ -121,10 +207,24 @@
         </article>
       </section>
 
+      <section class="insight-row">
+        <article class="story-card">
+          <header>
+            <h2>Story</h2>
+          </header>
+          <p id="storySummary">Load a dataset to generate automated insights.</p>
+          <ul id="anomalyHighlights" class="story-highlights" aria-live="polite"></ul>
+        </article>
+      </section>
+
       <section class="charts">
         <article class="chart-card">
           <div class="chart-header">
             <h2>Weekly Trend</h2>
+            <div class="chart-actions">
+              <button type="button" class="pill-button tertiary" data-chart="trend" data-export="png">Export PNG</button>
+              <button type="button" class="pill-button tertiary" data-chart="trend" data-export="csv">Export filtered CSV</button>
+            </div>
             <p>Aggregated by Sunday</p>
           </div>
           <div class="chart-area">
@@ -140,7 +240,19 @@
         <article class="chart-card">
           <div class="chart-header">
             <h2>Monthly Overview</h2>
-            <p>Totals grouped by month</p>
+            <div class="chart-actions">
+              <div class="chart-toggle-group" id="monthlyModeToggle" role="radiogroup" aria-label="Monthly view mode">
+                <button type="button" class="toggle-button small active" data-value="grouped" role="radio" aria-checked="true" tabindex="0">
+                  Grouped
+                </button>
+                <button type="button" class="toggle-button small" data-value="stacked" role="radio" aria-checked="false" tabindex="-1">
+                  Stacked
+                </button>
+              </div>
+              <button type="button" class="pill-button tertiary" data-chart="monthly" data-export="png">Export PNG</button>
+              <button type="button" class="pill-button tertiary" data-chart="monthly" data-export="csv">Export filtered CSV</button>
+            </div>
+            <p>Totals grouped by month across selected years</p>
           </div>
           <div class="chart-area">
             <canvas
@@ -158,42 +270,54 @@
               <h2>Distribution</h2>
               <p id="distributionLabel">Share by service</p>
             </div>
-            <div
-              class="chart-toggle-group"
-              id="distributionToggle"
-              role="radiogroup"
-              aria-label="Show distribution by"
-            >
-              <button
-                type="button"
-                class="toggle-button small active"
-                data-value="Service"
-                role="radio"
-                aria-checked="true"
-                tabindex="0"
+            <div class="chart-actions">
+              <div
+                class="chart-toggle-group"
+                id="distributionToggle"
+                role="radiogroup"
+                aria-label="Show distribution by"
               >
-                Service
-              </button>
-              <button
-                type="button"
-                class="toggle-button small"
-                data-value="Site"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-              >
-                Site
-              </button>
-              <button
-                type="button"
-                class="toggle-button small"
-                data-value="Year"
-                role="radio"
-                aria-checked="false"
-                tabindex="-1"
-              >
-                Year
-              </button>
+                <button
+                  type="button"
+                  class="toggle-button small active"
+                  data-value="Service"
+                  role="radio"
+                  aria-checked="true"
+                  tabindex="0"
+                >
+                  Service
+                </button>
+                <button
+                  type="button"
+                  class="toggle-button small"
+                  data-value="Site"
+                  role="radio"
+                  aria-checked="false"
+                  tabindex="-1"
+                >
+                  Site
+                </button>
+                <button
+                  type="button"
+                  class="toggle-button small"
+                  data-value="Year"
+                  role="radio"
+                  aria-checked="false"
+                  tabindex="-1"
+                >
+                  Year
+                </button>
+              </div>
+              <div class="chart-toggle-group" id="distributionViewToggle" role="radiogroup" aria-label="Distribution view type">
+                <button type="button" class="toggle-button small active" data-value="pie" role="radio" aria-checked="true" tabindex="0">
+                  Pie
+                </button>
+                <button type="button" class="toggle-button small" data-value="bar" role="radio" aria-checked="false" tabindex="-1">
+                  Bars
+                </button>
+              </div>
+              <button type="button" class="pill-button tertiary" data-chart="distribution" data-export="png">Export PNG</button>
+              <button type="button" class="pill-button tertiary" data-chart="distribution" data-export="csv">Export filtered CSV</button>
             </div>
           </div>
           <div class="chart-area">
@@ -211,18 +335,27 @@
       <section class="table-section">
         <div class="table-header">
           <h2>Recent Weeks</h2>
-          <p>Showing the latest 50 entries based on the selected filters.</p>
+          <div class="table-controls">
+            <label for="tablePageSize">Show</label>
+            <select id="tablePageSize">
+              <option value="50" selected>50</option>
+              <option value="100">100</option>
+              <option value="0">All</option>
+            </select>
+            <span>rows</span>
+          </div>
+          <p id="tableDescription">Showing the latest 50 entries based on the selected filters.</p>
         </div>
         <div class="table-wrapper">
           <table>
             <thead>
               <tr>
-                <th>Week</th>
-                <th>Date</th>
-                <th>Site</th>
-                <th>Service</th>
-                <th id="metricHeader">Attendance</th>
-                <th id="secondaryMetricHeader">Kids Checked-in</th>
+                <th data-key="IsoWeek" scope="col">ISO Week</th>
+                <th data-key="Date" scope="col">Date</th>
+                <th data-key="Site" scope="col">Site</th>
+                <th data-key="Service" scope="col">Service</th>
+                <th id="metricHeader" data-key="Attendance" scope="col">Attendance</th>
+                <th id="secondaryMetricHeader" data-key="Kids Checked-in" scope="col">Kids Checked-in</th>
               </tr>
             </thead>
             <tbody id="tableBody"></tbody>


### PR DESCRIPTION
## Summary
- add an empty-state experience, inline CSV help, and richer filter controls (search, select/clear, sticky KPI bar, insight story card, and export buttons)
- validate uploads with a Papa Parse web worker, normalize services, surface duplicate handling, add ISO week metadata, and persist dashboard state with zero-entry toggles and quick search
- extend charts with dual metrics, rolling averages, stacked/grouped monthly view, bar/pie distribution toggle, cross-filtering, and upgrade the table with sorting and row count controls plus filtered CSV/PNG exports

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d06676696083308b4f523e2a373dee