### PR TITLE
Add empty states for table and charts

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -140,6 +140,13 @@ function updateChartAriaLabel(canvas, description) {
   canvas.setAttribute('aria-label', description);
 }
 
+function setChartAreaState(canvas, hasData) {
+  if (!canvas) return;
+  const chartArea = canvas.closest('.chart-area');
+  if (!chartArea) return;
+  chartArea.classList.toggle('is-empty', !hasData);
+}
+
 function setDatasetStatus(message, type = 'info') {
   if (!elements.datasetStatus) return;
   elements.datasetStatus.textContent = message;
@@ -445,6 +452,7 @@ function updateTrendChart(filtered, metricKey) {
       ? `Line chart showing weekly ${metricDescription} totals.`
       : `Line chart showing weekly ${metricDescription} totals. No data available for the current filters.`
   );
+  setChartAreaState(elements.trendChartCanvas, hasData);
 
   if (!trendChart) {
     trendChart = new Chart(elements.trendChartCanvas, {
@@ -515,6 +523,7 @@ function updateMonthlyChart(filtered, metricKey) {
       ? `Bar chart showing monthly ${metricDescription} totals.`
       : `Bar chart showing monthly ${metricDescription} totals. No data available for the current filters.`
   );
+  setChartAreaState(elements.monthlyChartCanvas, hasData);
 
   if (!monthlyChart) {
     monthlyChart = new Chart(elements.monthlyChartCanvas, {
@@ -574,6 +583,7 @@ function updateDistributionChart(filtered, metricKey) {
       ? `Pie chart showing ${metricDescription} by ${dimensionDescription}.`
       : `Pie chart showing ${metricDescription} by ${dimensionDescription}. No data available for the current filters.`
   );
+  setChartAreaState(elements.distributionChartCanvas, hasData);
 
   if (!distributionChart) {
     distributionChart = new Chart(elements.distributionChartCanvas, {
@@ -611,20 +621,30 @@ function updateTable(filtered) {
     return cell;
   };
 
-  sorted.slice(0, 50).forEach((row) => {
-    const tableRow = document.createElement('tr');
+  if (!sorted.length) {
+    const emptyRow = document.createElement('tr');
+    emptyRow.className = 'table-empty-state';
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = 6;
+    emptyCell.textContent = 'No data matches your filters yet—try widening them.';
+    emptyRow.appendChild(emptyCell);
+    fragment.appendChild(emptyRow);
+  } else {
+    sorted.slice(0, 50).forEach((row) => {
+      const tableRow = document.createElement('tr');
 
-    tableRow.append(
-      createCell(row.Week),
-      createCell(formatDateLabel(row.Date)),
-      createCell(row.Site),
-      createCell(row.Service),
-      createCell(formatNumber(row[metricKey])),
-      createCell(formatNumber(row[secondaryKey]))
-    );
+      tableRow.append(
+        createCell(row.Week),
+        createCell(formatDateLabel(row.Date)),
+        createCell(row.Site),
+        createCell(row.Service),
+        createCell(formatNumber(row[metricKey])),
+        createCell(formatNumber(row[secondaryKey]))
+      );
 
-    fragment.appendChild(tableRow);
-  });
+      fragment.appendChild(tableRow);
+    });
+  }
 
   elements.tableBody.replaceChildren(fragment);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -394,6 +394,25 @@ body {
   height: 100% !important;
 }
 
+.chart-area.is-empty canvas {
+  opacity: 0.2;
+  filter: grayscale(0.6);
+}
+
+.chart-area.is-empty::after {
+  content: 'No data matches your filters yet—try widening them.';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 2rem;
+  font-weight: 500;
+  color: var(--muted);
+  pointer-events: none;
+}
+
 .chart-header {
   display: flex;
   justify-content: space-between;
@@ -494,6 +513,18 @@ tbody tr:nth-child(even) {
 
 tbody tr:hover {
   background: rgba(63, 106, 224, 0.12);
+}
+
+.table-empty-state,
+.table-empty-state:hover {
+  background: none !important;
+}
+
+.table-empty-state td {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--muted);
+  font-weight: 500;
 }
 
 .page-footer {


### PR DESCRIPTION
## Summary
- add DOM helper to flag chart containers when the filtered dataset is empty
- display a friendly empty state row when Recent Weeks has no matching rows
- style the table and chart empty states with centered guidance and muted canvases

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d06e5c2a5883309076e4eeb08eaeb2