### PR TITLE
Enhance dataset status and filter summary styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -81,17 +81,55 @@ body {
 }
 
 .dataset-status {
+  --status-color: var(--accent);
+  --status-bg: rgba(63, 106, 224, 0.12);
+  --status-border: rgba(63, 106, 224, 0.22);
+  --status-icon-bg: rgba(255, 255, 255, 0.95);
   margin: 0;
-  color: var(--muted);
-  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  background: var(--status-bg);
+  color: var(--status-color);
+  font-weight: 600;
+  border: 1px solid var(--status-border);
+  line-height: 1.2;
+}
+
+.dataset-status::before {
+  content: 'ⓘ';
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--status-icon-bg);
+  color: var(--status-color);
+  font-size: 0.95rem;
+  box-shadow: 0 4px 10px rgba(31, 41, 51, 0.12);
 }
 
 .dataset-status.success {
-  color: #2eb88a;
+  --status-color: #1f6f57;
+  --status-bg: rgba(46, 184, 138, 0.16);
+  --status-border: rgba(46, 184, 138, 0.32);
+}
+
+.dataset-status.success::before {
+  content: '✔';
 }
 
 .dataset-status.error {
-  color: #ef5b5b;
+  --status-color: #b63b3b;
+  --status-bg: rgba(239, 91, 91, 0.18);
+  --status-border: rgba(239, 91, 91, 0.32);
+}
+
+.dataset-status.error::before {
+  content: '⚠';
 }
 
 .data-actions {
@@ -275,9 +313,50 @@ body {
 }
 
 .filters-summary {
+  display: flex;
   padding: 0 0.5rem;
   color: var(--muted);
+}
+
+.filters-summary__content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: rgba(63, 106, 224, 0.1);
+  border: 1px solid rgba(63, 106, 224, 0.22);
   font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--text);
+  box-shadow: 0 8px 18px rgba(31, 41, 51, 0.08);
+}
+
+.filters-summary__content::before {
+  content: '🎯';
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: #fff;
+  color: var(--accent);
+  font-size: 0.9rem;
+  box-shadow: 0 4px 10px rgba(31, 41, 51, 0.12);
+}
+
+.filters-summary__label {
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+}
+
+#activeFilters {
+  font-weight: 600;
+  color: var(--text);
 }
 
 .summaries {
@@ -386,7 +465,8 @@ body {
 
 .chart-area {
   position: relative;
-  height: 220px;
+  min-height: 240px;
+  height: clamp(240px, 35vw, 420px);
 }
 
 .chart-area canvas {

--- a/index.html
+++ b/index.html
@@ -83,7 +83,10 @@
       </section>
 
       <section class="filters-summary">
-        <p id="activeFilters"></p>
+        <div class="filters-summary__content">
+          <span class="filters-summary__label">Current view</span>
+          <span id="activeFilters"></span>
+        </div>
       </section>
 
       <section class="summaries" aria-live="polite">


### PR DESCRIPTION
## Summary
- restyled the dataset status indicator with an icon badge treatment and distinct success/error themes
- wrapped the active filters copy in a styled summary badge with label text for clearer context
- made each chart area height responsive so visualizations scale with the viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d073bb373083309e23684aef0b645c