### PR TITLE
Enhance dashboard styling with layered accents

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -15,7 +15,12 @@
 
 body {
   margin: 0;
-  background: var(--bg);
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(63, 106, 224, 0.18), transparent 55%),
+    radial-gradient(circle at 85% 12%, rgba(168, 85, 247, 0.16), transparent 50%),
+    radial-gradient(circle at 50% 78%, rgba(46, 184, 138, 0.12), transparent 55%),
+    var(--bg);
   color: var(--text);
   line-height: 1.5;
 }
@@ -29,10 +34,26 @@ body {
 }
 
 .page-header {
+  position: relative;
   padding: 2.5rem 0 1.5rem;
   background: linear-gradient(120deg, #26418f, #3f6ae0);
   color: #fff;
   box-shadow: 0 4px 20px rgba(36, 64, 143, 0.2);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.page-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: clamp(120px, 18vw, 220px);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  clip-path: polygon(0% 68%, 12% 74%, 25% 62%, 38% 76%, 52% 60%, 66% 72%, 80% 57%, 92% 70%, 100% 62%, 100% 100%, 0% 100%);
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .page-header h1 {
@@ -42,6 +63,8 @@ body {
 }
 
 .page-header .layout-shell {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -218,13 +241,68 @@ body {
 }
 
 .controls {
+  position: relative;
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  background: var(--surface);
-  padding: 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.82));
+  padding: 1.75rem;
   border-radius: 1rem;
-  box-shadow: 0 10px 30px rgba(31, 41, 51, 0.08);
+  border: 1px solid rgba(63, 106, 224, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 10px 30px rgba(31, 41, 51, 0.08);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.controls::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(
+      rgba(63, 106, 224, 0.06) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(63, 106, 224, 0.06) 1px,
+      transparent 1px
+    );
+  background-size: 120px 120px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.controls > * {
+  position: relative;
+  z-index: 1;
+}
+
+.controls__badge {
+  grid-column: 1 / -1;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  background: rgba(63, 106, 224, 0.16);
+  border: 1px solid rgba(63, 106, 224, 0.28);
+  color: var(--accent);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  box-shadow: 0 8px 20px rgba(63, 106, 224, 0.18);
+}
+
+.controls__badge::before {
+  content: '';
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(63, 106, 224, 0.18);
 }
 
 .control-group {
@@ -368,7 +446,7 @@ body {
 .summary-card {
   --summary-accent: #3f6ae0;
   --summary-accent-soft: rgba(63, 106, 224, 0.18);
-  background: linear-gradient(135deg, var(--summary-accent-soft), rgba(255, 255, 255, 0.95));
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), var(--summary-accent-soft));
   padding: 1.5rem;
   border-radius: 1rem;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 18px 36px rgba(31, 41, 51, 0.1);
@@ -380,11 +458,31 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.summary-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 0.45rem;
+  background: linear-gradient(90deg, var(--summary-accent), rgba(255, 255, 255, 0));
+  opacity: 0.85;
+  pointer-events: none;
+}
+
 .summary-card::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: linear-gradient(150deg, rgba(255, 255, 255, 0.4), transparent 55%);
+  width: 170px;
+  height: 110px;
+  right: -50px;
+  bottom: -40px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0), var(--summary-accent));
+  background-blend-mode: screen;
+  clip-path: polygon(0% 68%, 12% 52%, 28% 60%, 44% 40%, 62% 58%, 78% 32%, 90% 44%, 100% 34%, 100% 100%, 0% 100%);
+  opacity: 0.35;
   pointer-events: none;
 }
 
@@ -457,13 +555,36 @@ body {
 }
 
 .chart-card {
+  position: relative;
   background: var(--surface);
   padding: 1.5rem;
   border-radius: 1rem;
-  box-shadow: 0 16px 32px rgba(31, 41, 51, 0.08);
+  border: 1px solid rgba(63, 106, 224, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 16px 32px rgba(31, 41, 51, 0.08);
+  overflow: hidden;
   height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.chart-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(63, 106, 224, 0.85), rgba(168, 85, 247, 0.55), rgba(46, 184, 138, 0.5));
+  pointer-events: none;
+}
+
+.chart-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 12px 24px rgba(36, 64, 143, 0.08);
+  pointer-events: none;
 }
 
 .chart-area {
@@ -530,10 +651,33 @@ body {
 }
 
 .table-section {
+  position: relative;
   background: var(--surface);
   border-radius: 1rem;
-  box-shadow: 0 16px 32px rgba(31, 41, 51, 0.08);
+  border: 1px solid rgba(63, 106, 224, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 16px 32px rgba(31, 41, 51, 0.08);
   padding: 1.5rem;
+  overflow: hidden;
+}
+
+.table-section::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(63, 106, 224, 0.85), rgba(168, 85, 247, 0.55), rgba(46, 184, 138, 0.5));
+  pointer-events: none;
+}
+
+.table-section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 12px 24px rgba(36, 64, 143, 0.08);
+  pointer-events: none;
 }
 
 .table-header {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
         </article>
       </section>
     
-      <section class="controls">
+      <section class="controls" aria-labelledby="filtersHeading">
+        <h2 class="controls__badge" id="filtersHeading">Filters</h2>
         <div class="control-group toggle-group">
           <span class="control-label" id="yearToggleLabel">Year</span>
           <div class="toggle-options" id="yearToggle" role="group" aria-labelledby="yearToggleLabel"></div>


### PR DESCRIPTION
## Summary
- add a radial-gradient background and wavy hero overlay to give the shell more depth
- refresh the filter controls with a badge heading and subtle grid texture for a refined card presentation
- update summary, chart, and table surfaces with accent strips, sparkline flair, and gentle inner shadows for cohesion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d182b974188330bf7ce41d504840ef