### PR TITLE
Adjust distribution charts spacing and responsiveness

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -593,6 +593,11 @@ function updateDistributionChart(filtered, metricKey) {
       mode: 'nearest',
       intersect: true
     },
+    layout: {
+      padding: {
+        bottom: 24
+      }
+    },
     plugins: {
       legend: {
         position: 'bottom'

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -558,6 +558,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-height: clamp(200px, 70vw, 340px);
+  height: clamp(220px, 75vw, 360px);
 }
 
 .chart-card--distribution .distribution-single {
@@ -576,8 +578,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  min-height: 220px;
-  height: clamp(220px, 24vw, 280px);
+  min-height: clamp(200px, 18vw, 260px);
+  height: clamp(220px, 20vw, 280px);
 }
 
 .chart-card--distribution .distribution-grid__label {
@@ -698,6 +700,7 @@ body {
 
   .chart-card--distribution .chart-area {
     height: auto;
+    min-height: 0;
   }
 
   .chart-card--distribution .distribution-single {


### PR DESCRIPTION
## Summary
- add bottom layout padding to distribution pie charts so legends have breathing room
- tweak distribution chart container heights to scale with smaller viewports and prevent overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d275f432988330a8794898e5d82a16