### PR TITLE
Replace top group summary with average growth

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -543,7 +543,7 @@ body {
   --summary-accent-soft: rgba(244, 162, 97, 0.24);
 }
 
-.summary-card.summary-top-group {
+.summary-card.summary-growth {
   --summary-accent: #a855f7;
   --summary-accent-soft: rgba(168, 85, 247, 0.24);
 }

--- a/index.html
+++ b/index.html
@@ -115,13 +115,13 @@
           <p id="summaryPeak" class="summary-value">0</p>
           <p class="summary-label" id="summaryPeakLabel"></p>
         </article>
-        <article class="summary-card summary-top-group">
+        <article class="summary-card summary-growth">
           <div class="summary-card__header">
-            <span class="summary-card__icon" aria-hidden="true">🏆</span>
-            <h2>Top Group</h2>
+            <span class="summary-card__icon" aria-hidden="true">📈</span>
+            <h2>Average Growth</h2>
           </div>
-          <p id="summaryTopGroup" class="summary-value">0</p>
-          <p class="summary-label" id="summaryTopGroupLabel"></p>
+          <p id="summaryAverageGrowth" class="summary-value">0%</p>
+          <p class="summary-label" id="summaryAverageGrowthLabel"></p>
         </article>
       </section>
 


### PR DESCRIPTION
## Summary
- replace the Top Group summary card with an Average Growth card that highlights percentage change
- compute average weekly growth across the selected timeframe and surface the relevant date range in the label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2a5c9afb88330b2ba753ac6a67369