### PR TITLE
Compute average week-to-week change

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
         <article class="summary-card summary-growth">
           <div class="summary-card__header">
             <span class="summary-card__icon" aria-hidden="true">📈</span>
-            <h2>Overall Change</h2>
+            <h2>Average Change</h2>
           </div>
           <p id="summaryAverageGrowth" class="summary-value">0%</p>
           <p class="summary-label" id="summaryAverageGrowthLabel"></p>


### PR DESCRIPTION
## Summary
- rename the summary card to "Average Change" to better reflect the metric being reported
- compute the average week-to-week percentage change across the filtered period
- refresh helper messaging so unavailable states reference the average change calculation

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d2aaa84ad083308a0146d395a0c7f6